### PR TITLE
 Allow more features from API endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,10 @@ import NotionExporter from "notion-exporter"
 const tokenV2 = ...
 const fileToken = ...
 const blockId = "3af0a1e347dd40c5ba0a2c91e234b2a5"
+const nofiles = false // download also PDF and image files
+const recursive = false // download only blockId
 
-await new NotionExporter(tokenV2, fileToken).getMdString(blockId)
+await new NotionExporter(tokenV2, fileToken, nofiles, recursive).getMdString(blockId)
 ```
 
 ### API
@@ -46,7 +48,7 @@ Provide the [required Cookies](#needed-cookies) as authentification to create a
 new exporter client.
 
 ```ts
-const exporter = new NotionExporter(tokenV2: string, fileToken: string)
+const exporter = new NotionExporter(tokenV2: string, fileToken: string, nofiles: boolean, recursive: boolean)
 ```
 
 #### Methods
@@ -66,6 +68,11 @@ second method also downloads the ZIP and gives full access to the
 ```ts
 exporter.getZipUrl(blockId: string): Promise<string>
 exporter.getZip(url: string): Promise<AdmZip>
+```
+
+Also chance to unzip all the exported files in the zip in a folder.
+```ts
+exporter.getMdFiles(blockId: string, folder: string): Promise<void>
 ```
 
 ## Needed Cookies

--- a/src/NotionExporter.ts
+++ b/src/NotionExporter.ts
@@ -49,7 +49,6 @@ export class NotionExporter {
       timeZone: "Europe/Zurich",
       locale: "en",
       collectionViewExportType: "currentView",
-      // includeContents: "no_files",
     }, this.noFilesIncluded ? { includeContents: "no_files" }: {});
     console.error(this.recursiveExport, exportOptions);
     const res = await this.client.post("enqueueTask", {

--- a/src/NotionExporter.ts
+++ b/src/NotionExporter.ts
@@ -12,6 +12,8 @@ interface Task {
 /** Lightweight client to export ZIP, Markdown or CSV files from a Notion block/page. */
 export class NotionExporter {
   protected readonly client: AxiosInstance
+  private readonly recursiveExport: boolean
+  private readonly noFilesIncluded: boolean
 
   /**
    * Create a new NotionExporter client. To export any blocks/pages from
@@ -21,13 +23,15 @@ export class NotionExporter {
    * @param tokenV2 – the Notion `token_v2` Cookie value
    * @param fileToken – the Notion `file_token` Cookie value
    */
-  constructor(tokenV2: string, fileToken: string) {
+  constructor(tokenV2: string, fileToken: string, noFiles: boolean, recursive: boolean = false) {
     this.client = axios.create({
       baseURL: "https://www.notion.so/api/v3/",
       headers: {
         Cookie: `token_v2=${tokenV2};file_token=${fileToken}`,
       },
     })
+    this.recursiveExport = recursive
+    this.noFilesIncluded = noFiles
   }
 
   /**
@@ -40,18 +44,21 @@ export class NotionExporter {
     const id = validateUuid(blockIdFromUrl(idOrUrl))
     if (!id) return Promise.reject(`Invalid URL or blockId: ${idOrUrl}`)
 
+    const exportOptions = Object.assign({
+      exportType: "markdown",
+      timeZone: "Europe/Zurich",
+      locale: "en",
+      collectionViewExportType: "currentView",
+      // includeContents: "no_files",
+    }, this.noFilesIncluded ? { includeContents: "no_files" }: {});
+    console.error(this.recursiveExport, exportOptions);
     const res = await this.client.post("enqueueTask", {
       task: {
         eventName: "exportBlock",
         request: {
           block: { id },
-          recursive: false,
-          exportOptions: {
-            exportType: "markdown",
-            timeZone: "Europe/Zurich",
-            locale: "en",
-            collectionViewExportType: "all",
-          },
+          recursive: this.recursiveExport,
+          exportOptions,
         },
       },
     })
@@ -115,8 +122,9 @@ export class NotionExporter {
   ): Promise<string> {
     const zip = await this.getZipUrl(idOrUrl).then(this.getZip)
     const entry = zip.getEntries().find(predicate)
+    const payload: string | undefined = entry?.getData().toString().trim()
     return (
-      entry?.getData().toString().trim() ||
+      payload ||
       Promise.reject("Could not find file in ZIP.")
     )
   }
@@ -143,4 +151,14 @@ export class NotionExporter {
    */
   getMdString = (idOrUrl: string): Promise<string> =>
     this.getFileString(idOrUrl, (e) => e.name.endsWith(".md"))
+
+  /**
+   * Downloads ane extracts into a folder all files in the exported zip file.
+   * @param idOrUrl BlockId or URL of the page/block/DB to export
+   * @param folder The folder where the files are going to be unzipped
+   */
+  getMdFiles = async (idOrUrl: string, folder: string): Promise<void> => {
+    const zip = await this.getZipUrl(idOrUrl).then(this.getZip)
+    zip.extractAllTo(folder)
+  }
 }

--- a/src/action.ts
+++ b/src/action.ts
@@ -25,7 +25,7 @@ const askToken = (tokenName: string): Promise<string> => {
 const envOrAskToken = async (tokenName: string) =>
   process.env[tokenName] || (await askToken(tokenName))
 
-const action = async (blockId: string, fileType: string) => {
+const action = async (blockId: string, fileType: string, noFiles: boolean, recursive: boolean = false) => {
   if (!isFileType(fileType)) {
     console.log(`File type (-t, --type) has to be one of: ${FileType}`)
     process.exit(1)
@@ -33,7 +33,7 @@ const action = async (blockId: string, fileType: string) => {
 
   const tokenV2 = await envOrAskToken("NOTION_TOKEN")
   const fileToken = await envOrAskToken("NOTION_FILE_TOKEN")
-  const exporter = new NotionExporter(tokenV2, fileToken)
+  const exporter = new NotionExporter(tokenV2, fileToken, noFiles, recursive)
 
   const outputStr =
     fileType === "csv"

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,8 @@ export const cli = (args: string[]) => {
 
     © ${pkg.author}, 2022.`
     )
+    .option('-r, --recursive', 'Export also subpages (default: false)')
+    .option('-n, --no-files', 'Don\'t export image and pdf files, only content (default: all content is exported)')
     .option("-t, --type", `File type to be exported: ${FileType}`, "md")
     //  .option("-o, --output", "Output path of the exported file, stdin if empty")
     .example(
@@ -29,6 +31,6 @@ export const cli = (args: string[]) => {
     .example("83715d7703ee4b8699b5e659a4712dd8 -t md")
     .example("3af0a1e347dd40c5ba0a2c91e234b2a5 -t csv > list.csv")
     //    .example("83715d7703ee4b8699b5e659a4712dd8 -t md -o blog.md")
-    .action((blockId, opts) => action(blockId, opts.type))
+    .action((blockId, opts) => action(blockId, opts.type, opts.n && true, opts.recursive))
     .parse(args)
 }


### PR DESCRIPTION
We needed to get exported a whole bunch of blocks children along with the parent to embed the documentation in a vector store. So, starting off you work we implemented chance to perform:
- recursive export
- enable/disable to export PDFs and images

Also, added a new method to unzip all exported files into a folder (for us that is useful to use [LangChain's NotionLoader]( https://js.langchain.com/docs/integrations/document_loaders/file_loaders/notion_markdown)